### PR TITLE
Apparent variable overflow

### DIFF
--- a/UbidotsArduinoGPRS.cpp
+++ b/UbidotsArduinoGPRS.cpp
@@ -342,7 +342,8 @@ bool Ubidots::sendAll(){
 bool Ubidots::sendAll(unsigned long timestamp_global) {
      
     int i;
-    char* allData = (char *) malloc(sizeof(char) * 700);   
+    char* allData = (char *) malloc(sizeof(char) * 700);
+    free(allData); //Find error on Arduino mini pro. Fixed with this instance, maybe variable overflow. More details in description
     char str_values[10];
     
     if (timestamp_global!= NULL) {


### PR DESCRIPTION
Checking out my Arduino Mini I found that sketch wasn't running correctly. For example, it did Setup(), Loop()1, Loop()2 and then Setup() again, so, it was doing an unexpected Reset. By the use of flags (multiple Serial.print) I pointed the error to sendall() code. Then, printing allData variable, I found an error on the char array during the second loop, so I thought it was like a memory overflow an tried with free() immediately after malloc() and worked very fine. I don't know why the free() at the end of the process is not working. Thanks for your work!