### PR TITLE
Added support to GSMCompact connectivity technology

### DIFF
--- a/src/UbiTcp.cpp
+++ b/src/UbiTcp.cpp
@@ -313,7 +313,11 @@ bool UbiTCP::_isNetworkRegistered() {
       //  Check wether the device is attach to GPRS network
       //  REG_OK_HOME = 1
       //  REG_OK_ROAMING = 5
-      isNetworkRegistered = (strstr(replybuffer, "0,1") != NULL) || (strstr(replybuffer, "0,5") != NULL);
+      isNetworkRegistered = (
+          strstr(replybuffer, "0,1") != NULL) 
+          || strstr(replybuffer, "1,1") != NULL) 
+          || (strstr(replybuffer, "0,5") != NULL
+        );
       isNetworkRegistered = isNetworkRegistered && CGATT && IP_INITIAL;
     }
 


### PR DESCRIPTION
Hello guys

I've identified an issue while trying to connect across GSM Compact radio station. For such situation, the AT command `AT+CREG?` will retrieve `1,1`, what means "GSM Compact, registered, home network" instead of the current `0,1` (GSM, registered, home network). Therefore, I'm submitting a PR proposing a minimal solution for this issue.

Regards.

